### PR TITLE
source session from ~/.op/session

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ support interactive signin).
 3. Symlink the script to somewhere on your `$PATH`: `ln -s $(pwd)/rofi-1pass ~/bin/rofi-1pass`.
 4. Run rofi with this as a custom script: `rofi -modi 1pass:rofi-1pass -show 1pass`.
 
+## Usage
+To use rofi-1pass with i3, or when executing via a keyboard shortcut that does not have access to your environment, you can do the following:
+1. Pipe the results of op signin $subdomain to ~/.op/session like so:
+```shell
+$ op signin my > ~/.op/session
+```
+2. Run rofi
+
 ## License
 
 Copyright © 2018 Adrian Petrescu. Code released under the MIT license.

--- a/rofi-1pass
+++ b/rofi-1pass
@@ -2,6 +2,8 @@
 set -e
 set -o pipefail
 
+source ~/.op/session
+
 print-account-list() {
   op list items | jq -r '.[] | " - \(.overview.title) (\(.overview.ainfo)) [\(.uuid)]"'
 }


### PR DESCRIPTION
when executing rofi with a keyboard shortcut, rofi-1pass does not have access to the environment variable OP_SESSION_$subdomain, leading to an empty box.

In this pull request I've added support for sourcing that variable from the location: ~/.op/session as well as instructions for generating that file.